### PR TITLE
Implement is_complete_request to add support for multiline editing

### DIFF
--- a/lib/handlers_v5.js
+++ b/lib/handlers_v5.js
@@ -38,9 +38,12 @@ module.exports = {
     complete_request: complete_request,
     inspect_request: inspect_request,
     shutdown_request: shutdown_request,
+    is_complete_request: is_complete_request,
 };
 
 var DEBUG = global.DEBUG || false;
+
+var esprima = require('esprima');
 
 var log;
 if (DEBUG) {
@@ -341,3 +344,21 @@ function shutdown_request(request) {
 
     status_idle.call(this, request);
 }
+
+function is_complete_request(request) {
+    try {
+        esprima.parse(request.content.code);
+    } catch(e) {
+        if (e.message.indexOf('Unexpected end of input') > -1) {
+            request.respond(this.shellSocket, "is_complete_reply", {
+                'status': 'incomplete',
+                'indent': '    '
+            });
+        } else {
+            request.respond(this.shellSocket, "is_complete_reply", {'status': 'invalid'});
+        }
+        return;
+    }
+    request.respond(this.shellSocket, "is_complete_reply", {'status': 'complete'});
+}
+

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
         "url": "https://github.com/n-riesco/jp-kernel.git"
     },
     "dependencies": {
+        "esprima": "^3.0.0",
         "jmp": "0.4.x",
         "nel": "0.5.x"
     },


### PR DESCRIPTION
A big feature of the IPython v5.0 messaging protocol that is missing in jp-kernel is the `is_complete_request` call, which allows for multi-line editing. This PR adds support for it.
