### PR TITLE
Support message handler additions/overrides on Kernel config

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,6 +7,7 @@
 # Please keep the list sorted.
 
 Benjamin Abel <bbig26@gmail.com>
+Frankie Dintino <fdintino@gmail.com>
 Kevin Kwok <kkwok@mit.edu>
 Mandar Vaze <mandarvaze@gmail.com>
 Min RK <benjaminrk@gmail.com>

--- a/lib/jp-kernel.js
+++ b/lib/jp-kernel.js
@@ -96,6 +96,8 @@ log = global.DEBUG ? doLog : dontLog;
  *                     transpile       If defined, this function transpiles the
  *                                     request code into Javascript that can be
  *                                     run by the Node.js session.
+ * @property {Object.<String, Function>}
+ *                     handlers        Additional message handlers
  */
 
 
@@ -208,9 +210,11 @@ function Kernel(config) {
      * @see {@link module:handler_v4}
      * @see {@link module:handler_v5}
      */
-    this.handlers = (majorVersion <= 4) ?
-        require("./handlers_v4.js") :
-        require("./handlers_v5.js");
+    this.handlers = Object.assign({},
+        (majorVersion <= 4) ?
+            require("./handlers_v4.js") :
+            require("./handlers_v5.js"),
+        config.handlers || {});
 
     this._bindSockets();
 

--- a/lib/jp-kernel.js
+++ b/lib/jp-kernel.js
@@ -263,7 +263,7 @@ Kernel.prototype._bindSockets = function() {
             this.handlers.shutdown_request.call(this, msg);
         } else {
             // Ignore unimplemented msg_type requests
-            console.warn("KERNEL: CONTROL: Unhandled message type:", msg_type);
+            console.warn("KERNEL: CONTROL: Unhandled message type:", msg.header.msg_type);
         }
     }
 };


### PR DESCRIPTION
This is an alternative proposal to PR #1, based on our conversation there.

It is intended to support n-riesco/ijavascript#81, which adds an "is_complete_request" message handler.
