### PR TITLE
fix: Provide a metadata object in the completion reply

### DIFF
--- a/lib/handlers_v5.js
+++ b/lib/handlers_v5.js
@@ -310,6 +310,7 @@ function complete_request(request) {
             cursor_start: result.completion.cursorStart,
             cursor_end: result.completion.cursorEnd,
             status: "ok",
+            metadata: {},
         };
         request.respond(this.shellSocket, "complete_reply", content);
     }


### PR DESCRIPTION
As per the documentation in https://jupyter-protocol.readthedocs.io/en/latest/messaging.html#msging-completion

Without this, jupyter-console breaks, because ptshell.py expects this field.
